### PR TITLE
No need to set h & y __block

### DIFF
--- a/NewsFourApp/LeftViewController.m
+++ b/NewsFourApp/LeftViewController.m
@@ -33,11 +33,11 @@
     [toNewViewbtn addTarget:self action:@selector(toNewViewbtn:) forControlEvents:UIControlEventTouchUpInside];
     [self.view addSubview:toNewViewbtn];
     
-    __block float h = self.view.frame.size.height*0.7/[_arData count];
-    __block float y = 0.15*self.view.frame.size.height;
+    float h = self.view.frame.size.height*0.7/[_arData count];
+    float y = 0.15*self.view.frame.size.height;
     [_arData enumerateObjectsUsingBlock:^(NSString *obj, NSUInteger idx, BOOL *stop)
     {
-        UIView *listV = [[UIView alloc] initWithFrame:CGRectMake(0, y, self.view.frame.size.width, h)];
+        UIView *listV = [[UIView alloc] initWithFrame:CGRectMake(0, y + h * idx, self.view.frame.size.width, h)];
         [listV setBackgroundColor:[UIColor clearColor]];
         UILabel *l = [[UILabel alloc] initWithFrame:CGRectMake(60, 0, listV.frame.size.width - 60, listV.frame.size.height)];
         [l setFont:[UIFont systemFontOfSize:20]];
@@ -46,7 +46,6 @@
         [l setText:obj];
         [listV addSubview:l];
         [self.view addSubview:listV];
-        y += h;
         
         UITapGestureRecognizer *tapGestureRec = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(backAction:)];
         [listV addGestureRecognizer:tapGestureRec];


### PR DESCRIPTION
when using [_arData enumerateObjectsUsingBlock:^(NSString *obj, NSUInteger idx, BOOL *stop)...];
You can use idx to set the frame for the list rather than set h and y __block.
